### PR TITLE
chore(deps): bump mkdocs-material to >=9.5.32

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install mkdocs            # install mkdocs 
-          python3 -m pip install mkdocs-material   # install material theme
+          python3 -m pip install "mkdocs-material>=9.5.32"   # install material theme
           python3 -m pip install mkdocs-include-markdown-plugin==3.8.1
           python3 -m pip install mkdocs-macros-plugin
       - name: Build mkdocs


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.