### PR TITLE
chore(deps): add dependabot configuration for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds Dependabot configuration to automatically monitor pip dependencies for security vulnerabilities and version updates.

This ensures the repository is alerted when dependencies have known issues.